### PR TITLE
feat: add option to specify whether to use cache; do not use cache for jest

### DIFF
--- a/src/esbuild.ts
+++ b/src/esbuild.ts
@@ -14,9 +14,10 @@ import cache from "./cache"
 export type TranspileOptions = {
   type: "bundle" | "transform"
   debug: boolean
-  esbuild?: CommonOptions & TransformOptions & BuildOptions
+  esbuild?: CommonOptions & TransformOptions & BuildOptions,
+  useCache: boolean,
 }
-const defaultOptions: TranspileOptions = { type: "bundle", debug: false }
+const defaultOptions: TranspileOptions = { type: "bundle", debug: false, useCache: true }
 
 const commonOptions: CommonOptions = {
   format: "cjs",
@@ -119,11 +120,15 @@ export function transpile(
     if (options.debug) console.log(`📦 ${filename}`)
     return _bundle(code, filename, options)
   } else if (options.type == "transform") {
-    return cache.get(filename, () => {
-      // eslint-disable-next-line no-console
-      if (options.debug) console.log(`📦 ${filename}`)
+    if (options.useCache) {
+      return cache.get(filename, () => {
+        // eslint-disable-next-line no-console
+        if (options.debug) console.log(`📦 ${filename}`)
+        return _transform(code, filename, options)
+      })
+    } else {
       return _transform(code, filename, options)
-    })
+    }
   }
   throw new Error(`Invalid transpilation option ${options.type}`)
 }

--- a/src/jest.ts
+++ b/src/jest.ts
@@ -2,7 +2,7 @@ import { transpile } from "./esbuild"
 import "./register"
 
 function process(src: string, filename: string) {
-  return transpile(src, filename, { type: "transform" })
+  return transpile(src, filename, { type: "transform", useCache: false })
 }
 
 export default { process }


### PR DESCRIPTION
We discovered an issue using `esbuild-runner/jest` with our product, [Wallaby.js](https://wallabyjs.com) where it was returning old file content for a new transformed file request because the file timestamp (used by the cache) is unchanged.

Jest has its own caching mechanism that is used when the file content is unchanged which means that the caching mechanism should be unnecessary when using jest.

I'm not sure what other contexts `esbuild-runner` is used, but for the case of jest, I've modified `esbuild-runner` to not use its internal cache.