### PR TITLE
chore: use public repository metadata URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "esbuild-runner",
   "version": "2.2.1",
   "description": "Super-fast on-the-fly transpilation of modern JS, TypeScript and JSX using esbuild",
-  "repository": "http://github.com/folke/esbuild-runner",
+  "repository": "git+https://github.com/folke/esbuild-runner.git",
   "main": "lib/index.js",
   "keywords": [
     "esbuild",


### PR DESCRIPTION
## Summary
- update the package `repository` metadata from an old GitHub HTTP URL to a public `git+https` URL
- leave runtime code, dependencies, package version, entry points, homepage/bugs metadata, and package contents unchanged

## Why
The published npm metadata currently resolves the repository to an SSH GitHub URL. The repository is public, so `git+https` is easier for npm users and package tooling that do not have GitHub SSH access configured.

## Validation
- `npm view esbuild-runner name version repository homepage bugs license --json`
- metadata assertion confirming `package.json` now uses `git+https://github.com/folke/esbuild-runner.git`
- `npm install --ignore-scripts --no-audit --no-fund --package-lock=false`
- `npm run lint`
- `npm run build`
- `npm pack --dry-run --ignore-scripts --json .` (6 package files)
- `git diff --check`
